### PR TITLE
Add more descriptive commit messages and fix issues with duplicate workflows

### DIFF
--- a/.github/workflows/website_publish.yml
+++ b/.github/workflows/website_publish.yml
@@ -12,6 +12,8 @@ jobs:
           
       - name: Skip Duplicate Actions
         uses: fkirc/skip-duplicate-actions@v2.1.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout Naev Repository
         uses: actions/checkout@v2

--- a/.github/workflows/website_publish.yml
+++ b/.github/workflows/website_publish.yml
@@ -9,6 +9,9 @@ jobs:
       - name: Event Information
         run: |
           echo "Event '${{ github.event.action }}' received from '${{ github.event.client_payload.repository }}'"
+          
+      - name: Skip Duplicate Actions
+        uses: fkirc/skip-duplicate-actions@v2.1.0
 
       - name: Checkout Naev Repository
         uses: actions/checkout@v2

--- a/.github/workflows/website_publish.yml
+++ b/.github/workflows/website_publish.yml
@@ -82,12 +82,23 @@ jobs:
           rsync -avzh build/docs/lua/ ${{ github.workspace }}/prod/api
         working-directory: staging
 
-      - name: Commit changes
+      - name: Add new file changes
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Actions"
           git add *
-          git commit -m "updates" -a
+        working-directory: prod
+
+      - name: Commit Website Changes
+        if: github.event.action == 'website'
+        run: |
+          git commit -m "Website Updates" -a
+        working-directory: prod
+
+      - name: Commit API Documentation Changes
+        if: github.event.action == 'api'
+        run: |
+          git commit -m "API Documentation Updates" -a
         working-directory: prod
 
       - name: Push changes


### PR DESCRIPTION
This makes the commits published by the Actions User more descriptive.
I initially just had this set to "updates" since that is what was being used before, but we may as well have more descriptive commit messages.