### PR TITLE
unidiff is no longer one big xml file

### DIFF
--- a/api/modules/diff.html
+++ b/api/modules/diff.html
@@ -154,7 +154,7 @@
 <p>Lua bindings to apply/remove Universe Diffs.</p>
 <p>
 <p> Universe Diffs are patches you can apply to the universe to make permanent
-  changes. They are defined in dat/unidiff.xml.
+  changes. They are defined in dat/unidiff/.
 <p> Typical usage would be:
  <pre>
  diff.apply( "collective_dead" )


### PR DESCRIPTION
update the API description due to unidiff now being a folder, not an xml file